### PR TITLE
Sync recipe with AnacondaRecipes

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,8 @@ requirements:
   host:
     - python
     - setuptools
+  build:
+    - {{ compiler('c') }}
   run:
     - python
     - attrs >=17.3.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - multidict >=4.0,<5.0
     - async-timeout >=3.0,<4.0
     - yarl >=1.0,<2.0
-    - idna_ssl >=1,<2  # [py35 or py36]
+    - idna_ssl >=1,<2
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
   skip: true  # [py2k]
 
 requirements:
-  build:
+  host:
     - python
     - setuptools
   run:
@@ -37,10 +37,12 @@ about:
   home: https://github.com/aio-libs/aiohttp
   license: Apache 2.0
   license_file: LICENSE.txt
+  license_family: Apache
   summary: 'Async http client/server framework (asyncio)'
 
   doc_url: http://aiohttp.readthedocs.io/
   dev_url: https://github.com/aio-libs/aiohttp
+  doc_source_url: https://github.com/aio-libs/aiohttp/tree/master/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,11 +17,11 @@ build:
   skip: true  # [py2k]
 
 requirements:
+  build:
+    - {{ compiler('c') }}
   host:
     - python
     - setuptools
-  build:
-    - {{ compiler('c') }}
   run:
     - python
     - attrs >=17.3.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - multidict >=4.0,<5.0
     - async-timeout >=3.0,<4.0
     - yarl >=1.0,<2.0
-    - idna_ssl >=1,<2
+    - idna_ssl >=1,<2  # [py<=36]
 
 test:
   imports:


### PR DESCRIPTION
Add items to about section.
Change which are recommended when using conda build 3 including compiler activation.
aiohttp is Python>=3.5 so idna_ssl is always required but not in Python 3.7+.
