### PR TITLE
allow chardet 4 since it has been released

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 9c1a81af067e72261c9cbe33ea792893e83bc6aa987bfbd6fdc1e5e7b22777c4
+  patches:
+    - pr5333.patch  # allows chardet 4.0
 
 build:
   number: 3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 9c1a81af067e72261c9cbe33ea792893e83bc6aa987bfbd6fdc1e5e7b22777c4
 
 build:
-  number: 2
+  number: 3
   script: {{ PYTHON }} -m pip install . -vv
   skip: true  # [py2k]
 
@@ -28,7 +28,7 @@ requirements:
     - python
     - async-timeout >=3.0,<4.0
     - attrs >=17.3.0
-    - chardet >=2.0,<4.0
+    - chardet >=2.0,<5.0
     - idna_ssl >=1.0  # [py<37]
     - multidict >=4.5,<7.0
     - typing-extensions >=3.6.5

--- a/recipe/pr5333.patch
+++ b/recipe/pr5333.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 428df5d..54462ba 100644
+--- a/setup.py
++++ b/setup.py
+@@ -66,7 +66,7 @@ except IndexError:
+ 
+ install_requires = [
+     "attrs>=17.3.0",
+-    "chardet>=2.0,<4.0",
++    "chardet>=2.0,<5.0",
+     "multidict>=4.5,<7.0",
+     "async_timeout>=3.0,<4.0",
+     "yarl>=1.0,<2.0",


### PR DESCRIPTION
Now that chardet 4 is released, expand the runtime requirement

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ x ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ x ] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

<-- I don't think re-rendering is needed since the latest accepted PR was only a few days ago -->
